### PR TITLE
feat: add --check flag for dns

### DIFF
--- a/internal/check/function.go
+++ b/internal/check/function.go
@@ -24,7 +24,7 @@ func CheckWithDNS(c *cli.Context) error {
 	fmt.Printf("| %-18s | %-10s |\n", "DNS Server", "Status")
 	fmt.Println("+--------------------+------------+")
 
-	dnsList, err := common.ReadDNSFromFile(common.DNS_CONFIG_FILE_CACHED)
+	dnsList, err := common.ReadDNSFromFile(common.DNS_CONFIG_FILE)
 	if err != nil {
 		err = common.DownloadConfigFile(common.DNS_CONFIG_URL, common.DNS_CONFIG_FILE)
 		if err != nil {

--- a/internal/common/function.go
+++ b/internal/common/function.go
@@ -24,11 +24,11 @@ const (
 	White   = "\033[97m"
 
 	// DNS config
-	DNS_CONFIG_FILE        = ".config/403unlocker/dns.conf"
-	DNS_CONFIG_FILE_CACHED = ".config/403unlocker/dns_cached.conf"
-	DOCKER_CONFIG_FILE     = ".config/403unlocker/dockerRegistry.conf"
-	DNS_CONFIG_URL         = "https://raw.githubusercontent.com/403unlocker/403Unlocker-cli/refs/heads/main/config/dns.conf"
-	DOCKER_CONFIG_URL      = "https://raw.githubusercontent.com/403unlocker/403Unlocker-cli/refs/heads/main/config/dockerRegistry.conf"
+	DNS_CONFIG_FILE         = ".config/403unlocker/dns.conf"
+	CHECKED_DNS_CONFIG_FILE = ".config/403unlocker/checked_dns.conf"
+	DOCKER_CONFIG_FILE      = ".config/403unlocker/dockerRegistry.conf"
+	DNS_CONFIG_URL          = "https://raw.githubusercontent.com/403unlocker/403Unlocker-cli/refs/heads/main/config/dns.conf"
+	DOCKER_CONFIG_URL       = "https://raw.githubusercontent.com/403unlocker/403Unlocker-cli/refs/heads/main/config/dockerRegistry.conf"
 )
 
 // FormatDataSize converts the size in bytes to a human-readable string in KB, MB, or GB.

--- a/internal/common/function.go
+++ b/internal/common/function.go
@@ -1,11 +1,14 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const (
@@ -21,10 +24,11 @@ const (
 	White   = "\033[97m"
 
 	// DNS config
-	DNS_CONFIG_FILE    = ".config/403unlocker/dns.conf"
-	DOCKER_CONFIG_FILE = ".config/403unlocker/dockerRegistry.conf"
-	DNS_CONFIG_URL     = "https://raw.githubusercontent.com/403unlocker/403Unlocker-cli/refs/heads/main/config/dns.conf"
-	DOCKER_CONFIG_URL  = "https://raw.githubusercontent.com/403unlocker/403Unlocker-cli/refs/heads/main/config/dockerRegistry.conf"
+	DNS_CONFIG_FILE        = ".config/403unlocker/dns.conf"
+	DNS_CONFIG_FILE_CACHED = ".config/403unlocker/dns_cached.conf"
+	DOCKER_CONFIG_FILE     = ".config/403unlocker/dockerRegistry.conf"
+	DNS_CONFIG_URL         = "https://raw.githubusercontent.com/403unlocker/403Unlocker-cli/refs/heads/main/config/dns.conf"
+	DOCKER_CONFIG_URL      = "https://raw.githubusercontent.com/403unlocker/403Unlocker-cli/refs/heads/main/config/dockerRegistry.conf"
 )
 
 // FormatDataSize converts the size in bytes to a human-readable string in KB, MB, or GB.
@@ -93,4 +97,70 @@ func DownloadConfigFile(url, path string) error {
 	}
 
 	return nil
+}
+
+func WriteDNSToFile(filename string, dnsList []string) error {
+	homeDir := os.Getenv("HOME")
+	if homeDir == "" {
+		fmt.Println("HOME environment variable not set")
+		os.Exit(1)
+	}
+
+	filename = homeDir + "/" + filename
+
+	_, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		file, err := os.Create(filename)
+		if err != nil {
+			fmt.Printf("Error creating file %s: %v\n", filename, err)
+			return err
+		}
+		file.Close()
+	}
+
+	content := strings.Join(dnsList, " ")
+
+	err = os.WriteFile(filename, []byte(content), 0644)
+	if err != nil {
+		fmt.Printf("Error writing to file %s: %v\n", filename, err)
+		return err
+	}
+
+	return nil
+}
+
+func ReadDNSFromFile(filename string) ([]string, error) {
+	homeDir := os.Getenv("HOME")
+	if homeDir == "" {
+		fmt.Println("HOME environment variable not set")
+		os.Exit(1)
+	}
+	filename = homeDir + "/" + filename
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	dnsServers := strings.Fields(string(data))
+	return dnsServers, nil
+}
+
+func ChangeDNS(dns string) *http.Client {
+	dialer := &net.Dialer{}
+	customResolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			dnsServer := fmt.Sprintf("%s:53", dns)
+			return dialer.DialContext(ctx, "udp", dnsServer)
+		},
+	}
+	customDialer := &net.Dialer{
+		Resolver: customResolver,
+	}
+	transport := &http.Transport{
+		DialContext: customDialer.DialContext,
+	}
+	client := &http.Client{
+		Transport: transport,
+	}
+	return client
 }

--- a/internal/dns/function.go
+++ b/internal/dns/function.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/cavaliergopher/grab/v3"
@@ -57,31 +58,37 @@ func CheckWithURL(c *cli.Context) error {
 	fmt.Println("+--------------------+----------------+")
 
 	tempDir := time.Now().UnixMilli()
+	var wg sync.WaitGroup
 	for _, dns := range dnsList {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
-		defer cancel()
+		wg.Add(1)
+		go func(dns string) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+			defer cancel()
 
-		clientWithCustomDNS := check.ChangeDNS(dns)
-		client := grab.NewClient()
-		client.HTTPClient = clientWithCustomDNS
+			clientWithCustomDNS := check.ChangeDNS(dns)
+			client := grab.NewClient()
+			client.HTTPClient = clientWithCustomDNS
 
-		req, err := grab.NewRequest(fmt.Sprintf("/tmp/%v", tempDir), fileToDownload)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating request for DNS %s: %v\n", dns, err)
-		}
-		req = req.WithContext(ctx)
+			req, err := grab.NewRequest(fmt.Sprintf("/tmp/%v", tempDir), fileToDownload)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error creating request for DNS %s: %v\n", dns, err)
+			}
+			req = req.WithContext(ctx)
 
-		resp := client.Do(req)
-		dnsSizeMap[dns] = resp.BytesComplete()
+			resp := client.Do(req)
+			dnsSizeMap[dns] = resp.BytesComplete()
 
-		speed := common.FormatDataSize(resp.BytesComplete() / int64(timeout))
-		if resp.BytesComplete() == 0 {
-			fmt.Printf("| %-18s | %s%-14s%s |\n", dns, common.Red, speed+"/s", common.Reset)
-		} else {
-			fmt.Printf("| %-18s | %-14s |\n", dns, speed+"/s")
-		}
+			speed := common.FormatDataSize(resp.BytesComplete() / int64(timeout))
+			if resp.BytesComplete() == 0 {
+				fmt.Printf("| %-18s | %s%-14s%s |\n", dns, common.Red, speed+"/s", common.Reset)
+			} else {
+				fmt.Printf("| %-18s | %-14s |\n", dns, speed+"/s")
+			}
+		}(dns)
 	}
 
+	wg.Wait()
 	// Print table footer
 	fmt.Println("+--------------------+----------------+")
 

--- a/internal/dns/function.go
+++ b/internal/dns/function.go
@@ -156,32 +156,29 @@ func CheckWithURL(c *cli.Context) error {
 	tempDir := time.Now().UnixMilli()
 	var wg sync.WaitGroup
 	for _, dns := range dnsList {
-		wg.Add(1)
-		go func(dns string) {
-			defer wg.Done()
-			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
-			defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+		defer cancel()
 
-			clientWithCustomDNS := common.ChangeDNS(dns)
-			client := grab.NewClient()
-			client.HTTPClient = clientWithCustomDNS
+		clientWithCustomDNS := common.ChangeDNS(dns)
+		client := grab.NewClient()
+		client.HTTPClient = clientWithCustomDNS
 
-			req, err := grab.NewRequest(fmt.Sprintf("/tmp/%v", tempDir), fileToDownload)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error creating request for DNS %s: %v\n", dns, err)
-			}
-			req = req.WithContext(ctx)
+		req, err := grab.NewRequest(fmt.Sprintf("/tmp/%v", tempDir), fileToDownload)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating request for DNS %s: %v\n", dns, err)
+		}
+		req = req.WithContext(ctx)
 
-			resp := client.Do(req)
-			dnsSizeMap[dns] = resp.BytesComplete()
+		resp := client.Do(req)
+		dnsSizeMap[dns] = resp.BytesComplete()
 
-			speed := common.FormatDataSize(resp.BytesComplete() / int64(timeout))
-			if resp.BytesComplete() == 0 {
-				fmt.Printf("| %-18s | %s%-14s%s |\n", dns, common.Red, speed+"/s", common.Reset)
-			} else {
-				fmt.Printf("| %-18s | %-14s |\n", dns, speed+"/s")
-			}
-		}(dns)
+		speed := common.FormatDataSize(resp.BytesComplete() / int64(timeout))
+		if resp.BytesComplete() == 0 {
+			fmt.Printf("| %-18s | %s%-14s%s |\n", dns, common.Red, speed+"/s", common.Reset)
+		} else {
+			fmt.Printf("| %-18s | %-14s |\n", dns, speed+"/s")
+		}
+
 	}
 
 	wg.Wait()

--- a/internal/dns/function.go
+++ b/internal/dns/function.go
@@ -3,13 +3,13 @@ package dns
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"sync"
 	"time"
 
 	"github.com/cavaliergopher/grab/v3"
-	"github.com/salehborhani/403Unlocker-cli/internal/check"
 	"github.com/salehborhani/403Unlocker-cli/internal/common"
 	"github.com/urfave/cli/v2"
 )
@@ -30,25 +30,121 @@ func URLValidator(URL string) bool {
 	}
 	return true
 }
-func CheckWithURL(c *cli.Context) error {
-	fileToDownload := c.Args().First()
-	timeout := c.Int("timeout")
 
-	dnsList, err := check.ReadDNSFromFile(common.DNS_CONFIG_FILE)
+func CheckAndCacheDNS(fileToDownload string) error {
+	cacheFile := common.DNS_CONFIG_FILE_CACHED
+
+	dnsList, err := common.ReadDNSFromFile(common.DNS_CONFIG_FILE)
 	if err != nil {
 		err = common.DownloadConfigFile(common.DNS_CONFIG_URL, common.DNS_CONFIG_FILE)
 		if err != nil {
+			fmt.Println("Error downloading DNS config file:", err)
 			return err
 		}
-		dnsList, err = check.ReadDNSFromFile(common.DNS_CONFIG_FILE)
 
+		dnsList, err = common.ReadDNSFromFile(common.DNS_CONFIG_FILE)
 		if err != nil {
-			fmt.Println("Error reading DNS list:", err)
+			fmt.Println("Error reading DNS list from file:", err)
 			return err
 		}
 	}
 
+	fmt.Println("\n+--------------------+------------+")
+	fmt.Printf("| %-18s | %-10s |\n", "DNS Server", "Status")
+	fmt.Println("+--------------------+------------+")
+
+	var validDNSList []string
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	for _, dns := range dnsList {
+		wg.Add(1)
+		go func(dns string) {
+			defer wg.Done()
+
+			// Set a 10-second timeout for the DNS lookup
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			client := common.ChangeDNS(dns)
+			req, err := http.NewRequestWithContext(ctx, "GET", fileToDownload, nil)
+			if err != nil {
+				mu.Lock()
+				fmt.Printf("| %-18s | %s%-10s%s |\n", dns, common.Red, "Error", common.Reset)
+				mu.Unlock()
+				return
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				mu.Lock()
+				fmt.Printf("| %-18s | %s%-10s%s |\n", dns, common.Red, "Failed", common.Reset)
+				mu.Unlock()
+				return
+			}
+			defer resp.Body.Close()
+
+			statusCode := resp.StatusCode
+			mu.Lock()
+			if statusCode == http.StatusOK {
+				fmt.Printf("| %-18s | %s%-10s%s |\n", dns, common.Green, "OK", common.Reset)
+				validDNSList = append(validDNSList, dns)
+			} else {
+				fmt.Printf("| %-18s | %s%-10s%s |\n", dns, common.Red, "Error", common.Reset)
+			}
+			mu.Unlock()
+		}(dns)
+	}
+
+	wg.Wait()
+
+	fmt.Println("+--------------------+------------+")
+
+	fmt.Println("Valid DNS List: ", validDNSList)
+
+	if len(validDNSList) > 0 {
+		err = common.WriteDNSToFile(cacheFile, validDNSList)
+		if err != nil {
+			fmt.Println("Error writing to cached DNS file:", err)
+			return err
+		}
+		fmt.Printf("Cached %d valid DNS servers to %s\n", len(validDNSList), cacheFile)
+	} else {
+		fmt.Println("No valid DNS servers found to cache.")
+	}
+
+	return nil
+}
+
+func CheckWithURL(c *cli.Context) error {
+	fileToDownload := c.Args().First()
+
+	// Determine the DNS list file based on the presence of the `--check` flag
+	var dnsFile string
+	if c.Bool("check") {
+		CheckAndCacheDNS(fileToDownload) // Update cached DNS if `--check` is used
+		dnsFile = common.DNS_CONFIG_FILE_CACHED
+	} else {
+		dnsFile = common.DNS_CONFIG_FILE
+	}
+
+	// Read the DNS list from the determined file
+	dnsList, err := common.ReadDNSFromFile(dnsFile)
+	if err != nil {
+		// Fallback to download and read from the original DNS file
+		err = common.DownloadConfigFile(common.DNS_CONFIG_URL, common.DNS_CONFIG_FILE)
+		if err != nil {
+			return fmt.Errorf("error downloading DNS config file: %w", err)
+		}
+		dnsList, err = common.ReadDNSFromFile(common.DNS_CONFIG_FILE)
+		if err != nil {
+			return fmt.Errorf("error reading DNS list from file: %w", err)
+		}
+	}
+
 	dnsSizeMap := make(map[string]int64)
+
+	timeout := c.Int("timeout")
 	fmt.Printf("\nTimeout: %d seconds\n", timeout)
 	fmt.Printf("URL: %s\n\n", fileToDownload)
 
@@ -66,7 +162,7 @@ func CheckWithURL(c *cli.Context) error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 			defer cancel()
 
-			clientWithCustomDNS := check.ChangeDNS(dns)
+			clientWithCustomDNS := common.ChangeDNS(dns)
 			client := grab.NewClient()
 			client.HTTPClient = clientWithCustomDNS
 

--- a/internal/dns/function.go
+++ b/internal/dns/function.go
@@ -122,7 +122,10 @@ func CheckWithURL(c *cli.Context) error {
 	// Determine the DNS list file based on the presence of the `--check` flag
 	var dnsFile string
 	if c.Bool("check") {
-		CheckAndCacheDNS(fileToDownload) // Update cached DNS if `--check` is used
+		err := CheckAndCacheDNS(fileToDownload) // Update cached DNS if `--check` is used
+		if err != nil {
+			return err
+		}
 		dnsFile = common.DNS_CONFIG_FILE_CACHED
 	} else {
 		dnsFile = common.DNS_CONFIG_FILE

--- a/internal/docker/function.go
+++ b/internal/docker/function.go
@@ -17,7 +17,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
-	"github.com/salehborhani/403Unlocker-cli/internal/check"
 	"github.com/salehborhani/403Unlocker-cli/internal/common"
 	"github.com/urfave/cli/v2"
 )
@@ -112,14 +111,14 @@ func CheckWithDockerImage(c *cli.Context) error {
 		return fmt.Errorf("image name cannot be empty")
 	}
 
-	registryList, err := check.ReadDNSFromFile(common.DOCKER_CONFIG_FILE)
+	registryList, err := common.ReadDNSFromFile(common.DOCKER_CONFIG_FILE)
 	if err != nil {
 		err = common.DownloadConfigFile(common.DOCKER_CONFIG_URL, common.DOCKER_CONFIG_FILE)
 		if err != nil {
 			return err
 		}
 
-		registryList, err = check.ReadDNSFromFile(common.DOCKER_CONFIG_FILE)
+		registryList, err = common.ReadDNSFromFile(common.DOCKER_CONFIG_FILE)
 		if err != nil {
 			log.Printf("Error reading registry list: %v", err)
 			return err

--- a/internal/unlockercli/cli.go
+++ b/internal/unlockercli/cli.go
@@ -66,25 +66,36 @@ func Run() {
 				Aliases: []string{"dns"},
 				Usage:   "Finds the fastest DNS SNI-Proxy for downloading a specific URL",
 				Description: `Examples:
-    403unlocker bestdns --timeout 15 https://packages.gitlab.com/gitlab/gitlab-ce/packages/el/7/gitlab-ce-16.8.0-ce.0.el7.x86_64.rpm/download.rpm`,
+			403unlocker bestdns --timeout 15 https://packages.gitlab.com/gitlab/gitlab-ce/packages/el/7/gitlab-ce-16.8.0-ce.0.el7.x86_64.rpm/download.rpm`,
 				Flags: []cli.Flag{
 					&cli.IntFlag{
 						Name:    "timeout",
-						Usage:   "Sets timeout",
+						Usage:   "Sets timeout in seconds",
 						Value:   10,
 						Aliases: []string{"t"},
 					},
+					&cli.BoolFlag{
+						Name:    "check",
+						Usage:   "Update the DNS cache before running the check",
+						Aliases: []string{"c"},
+					},
 				},
 				Action: func(cCtx *cli.Context) error {
-					if dns.URLValidator(cCtx.Args().First()) {
-						return dns.CheckWithURL(cCtx)
-					} else {
-						err := cli.ShowSubcommandHelp(cCtx)
-						if err != nil {
-							fmt.Println(err)
-						}
+					// Validate the URL argument
+					if cCtx.Args().Len() < 1 {
+						fmt.Println("Error: URL is required")
+						return cli.ShowSubcommandHelp(cCtx)
 					}
-					return nil
+
+					// Validate the provided URL
+					url := cCtx.Args().First()
+					if !dns.URLValidator(url) {
+						fmt.Println("Error: Invalid URL")
+						return cli.ShowSubcommandHelp(cCtx)
+					}
+
+					// Call CheckWithURL with the current context
+					return dns.CheckWithURL(cCtx)
 				},
 			},
 		},


### PR DESCRIPTION
Added --check Flag for DNS

Purpose
Allows users to update the DNS cache before running the DNS performance check.

Command

./403unlocker dns -c "https://packages.gitlab.com/gitlab/gitlab-ce/packages/el/7/gitlab-ce-16.8.0-ce.0.el7.x86_64.rpm/download.rpm"

or

./403unlocker dns --check "https://packages.gitlab.com/gitlab/gitlab-ce/packages/el/7/gitlab-ce-16.8.0-ce.0.el7.x86_64.rpm/download.rpm"

Behavior

    If --check (or -c) is specified:
        Executes CheckAndCacheDNS(fileToDownload) to validate and cache working DNS servers into common.DNS_CONFIG_FILE_CACHED.
        Reads the DNS list from common.DNS_CONFIG_FILE_CACHED.

    If --check is not specified:
        Reads the DNS list directly from common.DNS_CONFIG_FILE.

Modified CheckWithURL

Changes
- Dynamically selects the DNS list file based on the presence of the --check flag:

```go
if c.Bool("check") {
        CheckAndCacheDNS(fileToDownload)
        dnsFile = common.DNS_CONFIG_FILE_CACHED
    } else {
        dnsFile = common.DNS_CONFIG_FILE
    }
```