### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN_DIR = ~/.local/bin
 CONFIG_DIR= ~/.config/403unlocker
 DNS_CONFIG_FILE_URL=https://raw.githubusercontent.com/403unlocker/403Unlocker-cli/refs/heads/main/config/dns.conf
 DOCKER_CONFIG_FILE_URL=https://raw.githubusercontent.com/403unlocker/403Unlocker-cli/refs/heads/main/config/dockerRegistry.conf
-
+GOPROXY ?= https://goproxy.cn,direct
 .DEFAULT_GOAL := help
 
 .PHONY: help lint build test clean install uninstall
@@ -24,7 +24,8 @@ lint:
 
 build:
 	@go build -o $(OUTPUT) $(MAIN)
-
+	@echo "Building with GOPROXY=$(GOPROXY)..."
+	GOPROXY=$(GOPROXY) go env -w GOPROXY=$(GOPROXY)
 
 test: 
 	@go test ./...


### PR DESCRIPTION
fix: set GOPROXY in Makefile to resolve module access issues in Iran

While building the project, we encountered multiple 403 Forbidden errors where Go couldn’t fetch some dependencies from its default proxy (https://proxy.golang.org). This issue was tested across different systems — locally, inside Docker, and even directly in the terminal — and the result was always the same.

One example of a blocked resource:

https://storage.googleapis.com/proxy-golang-org-prod/09715be4772b9940-github.com:klauspost:compress-v1.16.5.zip

Trying to access it returned an XML error like this:

<Error>
  <Code>AccessDenied</Code>
  <Message>Access denied.</Message>
  <Details>We're sorry, but this service is not available in your location</Details>
</Error>
To solve this, we updated the Makefile so the GOPROXY value can be passed when running make build, e.g.:

make build GOPROXY=https://goproxy.cn,direct
And we added the following line in the Makefile:

go env -w GOPROXY=$(GOPROXY)
This allows us to build the project without manually setting the proxy every time, and makes it work seamlessly in CI environments or Docker containers.

The fix was tested in multiple environments and worked successfully.

![bug2](https://github.com/user-attachments/assets/fdeab2d2-7c74-4e59-aad3-5772b64af2d2)

